### PR TITLE
Round init behavior

### DIFF
--- a/src/classes/scenes/RoundScene.ts
+++ b/src/classes/scenes/RoundScene.ts
@@ -23,11 +23,15 @@ export class RoundScene implements Scene {
     this.id++;
 
     const availablePlayerRoles = this.availablePlayerRoles;
-    const duration = this.isFirstRound ? this.duration : this.duration * gameProperties.duration.decreaseCoefficient;
+    const duration = this.isFirstRound
+      ? this.duration
+      : Math.round(this.duration * gameProperties.duration.decreaseCoefficient);
     const playerRoles: PlayerRoles = {};
     const playerIds = Array.from(this.room.players.keys());
     const skins = shuffle(Object.values(enums.member.Skins));
     const world: enums.World = getRandomArrayElement(Object.values(enums.World));
+
+    this.duration = duration;
 
     for (let i = 0; i < gameProperties.members; i++) {
       this.members[`member-${i + 1}`] = {
@@ -68,6 +72,8 @@ export class RoundScene implements Scene {
   start() {
     this.interval = setInterval(this.tick.bind(this), gameProperties.tick);
     emitGlobal<payloads.round.Start>({ roomId: this.room.id, eventName: events.round.start });
+
+    // TODO: Start timer based on this.duration value to trigger this.fail()
   }
 
   fail() {
@@ -148,6 +154,7 @@ export class RoundScene implements Scene {
     return this.id === 1;
   }
 
+  // TODO: Type return
   get availablePlayerRoles() {
     const array = [
       {

--- a/src/classes/scenes/RoundScene.ts
+++ b/src/classes/scenes/RoundScene.ts
@@ -11,8 +11,8 @@ export class RoundScene implements Scene {
   id = 0;
   interval: NodeJS.Timeout;
 
-  duration = gameProperties.duration.defaultValue;
-  trapInterval = gameProperties.traps.defaultInterval;
+  duration = gameProperties.variables.duration.defaultValue;
+  trapInterval = gameProperties.variables.traps.defaultInterval;
   world: enums.World;
   members: Members = {};
 
@@ -27,7 +27,7 @@ export class RoundScene implements Scene {
 
     const duration = this.isFirstRound
       ? this.duration
-      : Math.round(this.duration * gameProperties.duration.decreaseCoefficient);
+      : Math.round(this.duration * gameProperties.variables.duration.decreaseCoefficient);
     const playerRoles: PlayerRoles = {};
     const playerIds = Array.from(this.room.players.keys());
     const skins = shuffle(Object.values(enums.member.Skins));
@@ -161,7 +161,7 @@ export class RoundScene implements Scene {
   get availablePlayerRoles(): PlayerRole[] {
     const trapInterval = this.isFirstRound
       ? this.trapInterval
-      : Math.round(this.trapInterval * gameProperties.traps.decreaseCoefficient);
+      : Math.round(this.trapInterval * gameProperties.variables.traps.decreaseCoefficient);
     const array = [
       {
         role: enums.player.Role.platform,
@@ -171,20 +171,31 @@ export class RoundScene implements Scene {
         role: enums.player.Role.trap,
         properties: { type: getRandomArrayElement(Object.values(enums.Traps[this.world])), interval: trapInterval },
       },
-      // TODO: Add more traps depending difficulty & player length
     ];
-    const offset = array.length;
+    const trapsToAdd =
+      Math.floor(this.id / gameProperties.difficultyStep) > this.room.players.size - array.length
+        ? this.room.players.size - array.length
+        : Math.floor(this.id / gameProperties.difficultyStep);
+    const offset = array.length + trapsToAdd;
 
-    for (let i = 0; i < this.room.players.size - offset; i++)
+    // Add traps
+    for (let i = 0; i < trapsToAdd; i++) {
+      array.push({
+        role: enums.player.Role.trap,
+        properties: { type: getRandomArrayElement(Object.values(enums.Traps[this.world])), interval: trapInterval },
+      });
+    }
+
+    // Add blank to available space
+    for (let i = 0; i < this.room.players.size - offset; i++) {
       array.push({
         role: enums.player.Role.blank,
         properties: null,
       });
+    }
 
     this.trapInterval = trapInterval;
 
-    const result = shuffle(array);
-    console.log(result);
     return shuffle(array);
   }
 }

--- a/src/classes/scenes/TransitionScene.ts
+++ b/src/classes/scenes/TransitionScene.ts
@@ -44,6 +44,6 @@ export class TransitionScene implements Scene {
   }
 
   clear() {
-    console.log('CLEAR');
+    console.log('CLEAR TRANSITION SCENE');
   }
 }

--- a/src/config/game-properties.ts
+++ b/src/config/game-properties.ts
@@ -1,9 +1,5 @@
-import { enums } from '@colobobo/library';
-
 export const gameProperties = {
-  difficulty: {
-    step: Object.keys(enums.World).length,
-  },
+  difficultyStep: 3,
   duration: {
     defaultValue: 30000,
     decreaseCoefficient: 0.95,
@@ -15,4 +11,8 @@ export const gameProperties = {
     max: 6,
   },
   tick: (1000 / 60) * 2,
+  traps: {
+    defaultInterval: 5000,
+    decreaseCoefficient: 0.98,
+  },
 };

--- a/src/config/game-properties.ts
+++ b/src/config/game-properties.ts
@@ -1,8 +1,18 @@
+import { enums } from '@colobobo/library';
+
 export const gameProperties = {
+  difficulty: {
+    step: Object.keys(enums.World).length,
+  },
+  duration: {
+    defaultValue: 30000,
+    decreaseCoefficient: 0.95,
+  },
+  life: 4,
+  members: 5,
   players: {
     min: 3,
     max: 6,
   },
   tick: (1000 / 60) * 2,
-  life: 4,
 };

--- a/src/config/game-properties.ts
+++ b/src/config/game-properties.ts
@@ -1,18 +1,17 @@
 export const gameProperties = {
   difficultyStep: 3,
-  duration: {
-    defaultValue: 30000,
-    decreaseCoefficient: 0.95,
-  },
   life: 4,
   members: 5,
-  players: {
-    min: 3,
-    max: 6,
-  },
+  players: { min: 3, max: 6 },
   tick: (1000 / 60) * 2,
-  traps: {
-    defaultInterval: 5000,
-    decreaseCoefficient: 0.98,
+  variables: {
+    duration: {
+      defaultValue: 30000,
+      decreaseCoefficient: 0.95,
+    },
+    traps: {
+      defaultInterval: 5000,
+      decreaseCoefficient: 0.98,
+    },
   },
 };

--- a/src/sockets/room.ts
+++ b/src/sockets/room.ts
@@ -19,7 +19,6 @@ export const create = function(device: payloads.room.Create) {
       events.room.createSuccess,
       emitCallback<payloads.room.CreateSuccess>({ id: uid, deviceId: player.id }),
     );
-    log(`Created room ${uid}`);
   });
 };
 
@@ -38,7 +37,6 @@ export const join = function(args: payloads.room.Join) {
           events.room.joinSuccess,
           emitCallback<payloads.room.JoinSuccess>({ id, deviceId: player.id }),
         );
-        log(`Joined room ${id}`);
       });
     } else {
       this.emit(events.room.joinError, emitErrorCallback<payloads.room.JoinError>(2, 'Room is full'));

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,6 +1,6 @@
 export const getRandomArrayElement = (array: any[]) => array[Math.floor(Math.random() * array.length)];
 
-export const shuffle = (array: any[]) => {
+export const shuffle = (array: any[]): any[] => {
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]];

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,9 @@
+export const getRandomArrayElement = (array: any[]) => array[Math.floor(Math.random() * array.length)];
+
+export const shuffle = (array: any[]) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
-export { emitCallback, emitErrorCallback, emitGlobal, emitErrorGlobal } from './emit';
-export { log } from './logs';
-export { generateUid } from './uid';
+export * from './emit';
+export * from './logs';
+export * from './array';
+export * from './uid';


### PR DESCRIPTION
## Description
This PR define the init procedure of a round.

Closes #14

## Todos
- [x] Increment round `id`
- [x] Define and decrease round duration
- [x] Define randomly a world
- [x] Initialise member information with a random skin
- [x] Define player roles 
  - [x] `platform` & one `trap` by default
  - [x] All remaining players are set to `blank`
  - [x] Add trap(s) depending players length & difficulty
  - [x] Provide trap type depending world
  - [x] Provide traps properties
