### PR TITLE
feat(round): Check all players to be ready before start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "@colobobo/library": {
-      "version": "git+https://github.com/colobobo/library.git#fc5b8e342fc00f32ef50c7ea2f4c0ef4cf6c214f",
+      "version": "git+https://github.com/colobobo/library.git#84a8041a58932943d228539d689ae2c202be726d",
       "from": "git+https://github.com/colobobo/library.git",
       "requires": {
         "prettier": "^2.0.1",

--- a/src/classes/scenes/RoundScene.ts
+++ b/src/classes/scenes/RoundScene.ts
@@ -70,8 +70,7 @@ export class RoundScene implements Scene {
 
   playerReady(player: Player) {
     player.isReady = true;
-    // TODO: If all ready => start round
-    this.start();
+    if (Array.from(this.room.players.values()).every(player => player.isReady)) this.start();
   }
 
   start() {


### PR DESCRIPTION
## Description
This PR checks if all players are ready before start a round.

Closes #15

## Todos
- [x] Implement check
