### PR TITLE
Play / pause status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "@colobobo/library": {
-      "version": "git+https://github.com/colobobo/library.git#fb59387416f1e499511ecd7f765a62459c27c1e0",
+      "version": "git+https://github.com/colobobo/library.git#028a9507762e10e7b8465de864675b37a1c042fc",
       "from": "git+https://github.com/colobobo/library.git",
       "requires": {
         "prettier": "^2.0.1",

--- a/src/classes/Room.ts
+++ b/src/classes/Room.ts
@@ -34,6 +34,10 @@ export class Room implements RoomInterface {
     player.socket.on(events.transition.playerReady, () => this.game.transitionScene.playerReady(player));
     player.socket.on(events.round.playerReady, () => this.game.roundScene.playerReady(player));
 
+    player.socket.on(events.round.statusUpdate, (payload: payloads.round.StatusUpdate) =>
+      this.game.roundScene.updateStatus(payload),
+    );
+
     player.socket.on(events.round.memberSpawned, (payload: payloads.round.MemberSpawned) =>
       this.game.roundScene.memberSpawned(payload),
     );

--- a/src/classes/scenes/RoundScene.ts
+++ b/src/classes/scenes/RoundScene.ts
@@ -82,7 +82,13 @@ export class RoundScene implements Scene {
 
   start() {
     console.log(events.round.start);
-    emitGlobal<payloads.round.Start>({ roomId: this.room.id, eventName: events.round.start });
+    emitGlobal<payloads.round.Start>({
+      roomId: this.room.id,
+      eventName: events.round.start,
+      data: {
+        endRoundTimeStamp: new Date().getTime() + this.duration,
+      },
+    });
     this.tick = setInterval(this.emitTick.bind(this), gameProperties.tick);
     this.timer = setTimeout(this.fail.bind(this), this.duration);
     this.startTimestamp = new Date();
@@ -90,7 +96,7 @@ export class RoundScene implements Scene {
 
   restart() {
     this.tick = setInterval(this.emitTick.bind(this), gameProperties.tick);
-    this.timer = setTimeout(this.fail.bind(this), this.duration - this.elapsedTime);
+    this.timer = setTimeout(this.fail.bind(this), this.remainingTime);
     this.startTimestamp = new Date();
   }
 
@@ -134,7 +140,10 @@ export class RoundScene implements Scene {
     emitGlobal<payloads.round.StatusUpdateSuccess>({
       roomId: this.room.id,
       eventName: events.round.statusUpdateSuccess,
-      data: { status },
+      data: {
+        status,
+        endRoundTimeStamp: new Date().getTime() + this.remainingTime,
+      },
     });
   }
 
@@ -250,6 +259,10 @@ export class RoundScene implements Scene {
 
   get elapsedTime() {
     return this.playedIntervals.reduce((accumulator, currentValue) => accumulator + currentValue);
+  }
+
+  get remainingTime() {
+    return this.duration - this.elapsedTime;
   }
 
   get information(): round.Information {

--- a/src/sockets/room.ts
+++ b/src/sockets/room.ts
@@ -19,6 +19,7 @@ export const create = function(event: payloads.room.Create) {
     }
 
     global.rooms.set(uid, room);
+    console.log('CREATED ROOM', uid);
 
     this.emit(
       events.room.createSuccess,


### PR DESCRIPTION
## Description
This PR provides toggle of play / pause into a round.

Closes #20 

## Todos
- [x] Rename `interval` & `timeout` to `tick` & `timer`
- [x] Add `playedIntervals` which is the sum of all intervals whiles round is playing
- [x] Restart timer with `duration - elapsedTime` while restart round
- [x] Send `endRoundTimestamp` into `payloads.round.StartSuccess` & `payloads.round.StatusUpdateSuccess`
