### PR TITLE
Add scoreDetails at the end of a round

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "@colobobo/library": {
-      "version": "git+https://github.com/colobobo/library.git#cf26a30c58e85474d9d156e7485b7a484d75f198",
+      "version": "git+https://github.com/colobobo/library.git#ecbb35b5d6e8765dbf7f11028baad190b2f84a4d",
       "from": "git+https://github.com/colobobo/library.git",
       "requires": {
         "prettier": "^2.0.1",


### PR DESCRIPTION
## Description
This PR provides `scoreDetails` at the end of a round.

Closes #41

